### PR TITLE
in case np.arange sometimes include the stop value in some cases when…

### DIFF
--- a/profane/config_option.py
+++ b/profane/config_option.py
@@ -91,7 +91,10 @@ def _parse_string_as_range(s, item_type):
         return list(range(start, stop, step))
     elif item_type == float:
         precision = max(_rounding_precision(x) for x in (start, stop, step))
-        return [round(item, precision) for item in np.arange(start, stop, step)]
+        lst = [round(item, precision) for item in np.arange(start, stop, step)]
+        if lst[-1] == stop:
+            del lst[-1]
+        return lst
 
     raise ValueError(f"unsupported type: {item_type}")
 

--- a/tests/test_config_types.py
+++ b/tests/test_config_types.py
@@ -71,7 +71,8 @@ def test_convert_string_to_list():
     # test range conversions
     assert convert_string_to_list("1..4,1", int) == (1, 2, 3)
     assert convert_string_to_list("1..4,0.5", float) == (1, 1.5, 2, 2.5, 3, 3.5)
-    assert convert_string_to_list("0.00001..0.00002,2e-06", float) == (1e-05, 1.2e-05, 1.4e-05, 1.6e-05, 1.8e-05, 2e-05)
+    assert convert_string_to_list("0.65..0.8,0.05", float) == (0.65, 0.7, 0.75)
+    assert convert_string_to_list("0.00001..0.00002,2e-06", float) == (1e-05, 1.2e-05, 1.4e-05, 1.6e-05, 1.8e-05)
 
     # test range checking endpoints
     assert convert_string_to_list("1,2,3,4,6", int) == (1, 2, 3, 4, 6)


### PR DESCRIPTION
… step is float value;

to address previous failing case: 
```
[0.65, 0.7, 0.75] -> 0.65..0.8,0.05 -> **[0.65, 0.7, 0.75, 0.8]**
```

reason (from np.arange [docs](https://numpy.org/doc/stable/reference/generated/numpy.arange.html))
> _stop: number_
end of interval. The interval does not include this value, **except in some cases where step is not an integer and floating point round-off affects the length of out.**