### PR TITLE
Config options can be passed via text files

### DIFF
--- a/profane/cli.py
+++ b/profane/cli.py
@@ -1,13 +1,7 @@
 def config_list_to_dict(l):
     d = {}
-    for kv in l:
-        if kv.count("=") != 1:
-            raise ValueError(f"invalid 'key=value' pair: {kv}")
 
-        k, v = kv.split("=")
-        if len(v) == 0:
-            raise ValueError(f"invalid 'key=value' pair: {kv}")
-
+    for k, v in _config_list_to_pairs(l):
         _dot_to_dict(d, k, v)
 
     return d
@@ -24,5 +18,25 @@ def _dot_to_dict(d, k, v):
 
         d.setdefault(current_k, {})
         _dot_to_dict(d[current_k], remaining_path, v)
+    elif k == "file":
+        with open(v, "rt") as f:
+            for new_k, new_v in _config_list_to_pairs([line for line in f]):
+                _dot_to_dict(d, new_k, new_v)
     else:
         d[k] = v
+
+
+def _config_list_to_pairs(l):
+    pairs = []
+    for kv in l:
+        kv = kv.strip()
+        if kv.count("=") != 1:
+            raise ValueError(f"invalid 'key=value' pair: {kv}")
+
+        k, v = kv.split("=")
+        if len(v) == 0:
+            raise ValueError(f"invalid 'key=value' pair: {kv}")
+
+        pairs.append((k, v))
+
+    return pairs

--- a/tests/test_config_string.py
+++ b/tests/test_config_string.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 from profane.cli import config_list_to_dict
@@ -25,3 +26,23 @@ def test_config_string_to_dict():
     with pytest.raises(ValueError):
         args = [".invalid=1"]
         config_list_to_dict(args)
+
+
+def test_config_string_with_files_to_dict(tmpdir):
+    mainfn = os.path.join(tmpdir, "main.txt")
+    with open(mainfn, "wt") as f:
+        print("main=24", file=f)
+
+    foofn = os.path.join(tmpdir, "foo.txt")
+    with open(foofn, "wt") as f:
+        print("test1=20", file=f)
+        print("submod1.test1=21", file=f)
+        print("submod1.submod2.test1=22", file=f)
+        print("test3=extra", file=f)
+        print(f"file={mainfn}", file=f)
+
+    args = ["foo.test1=1", f"foo.file={foofn}", "main=42", f"file={mainfn}"]
+    assert config_list_to_dict(args) == {
+        "foo": {"test1": "20", "test3": "extra", "main": "24", "submod1": {"test1": "21", "submod2": {"test1": "22"}}},
+        "main": "24",
+    }


### PR DESCRIPTION
The `file` config key is now special. Using it results in config options being loaded from the specified file.

For example:
```
$ cat cfg.txt
someval=1
another=2
```

The config string `file=cfg.txt searcher.index.file=cfg.txt` will be expanded to:
 `someval=1 another=2 searcher.index.someval=1 searcher.index.another=2`.