### PR TITLE
Flexible types for config and provide

### DIFF
--- a/profane/base.py
+++ b/profane/base.py
@@ -249,6 +249,12 @@ class ModuleBase:
         if isinstance(config, FrozenDict):
             config = config._as_dict()
 
+        if isinstance(provide, ModuleBase):
+            provide = [provide]
+
+        if isinstance(provide, (list, tuple)):
+            provide = {module.module_type: module for module in provide}
+
         # it is important that we create a new provide object here, because _instantiate_dependencies may add entries to it.
         # we don't want those entries to propagate higher in the module graph.
         # see the test with 'threerank_separate' in test_task_pipeline.py for illustration.

--- a/profane/base.py
+++ b/profane/base.py
@@ -7,6 +7,7 @@ from glob import glob
 
 from colorama import Style, Fore
 
+from profane.cli import config_string_to_dict
 from profane.config_option import ConfigOption
 from profane.exceptions import PipelineConstructionError, InvalidConfigError, InvalidModuleError
 from profane.frozendict import FrozenDict
@@ -241,6 +242,9 @@ class ModuleBase:
         # create new objects to prevent them from being shared with other class instances
         self._dependency_objects = {}
         self._provided_dependency = set()
+
+        if isinstance(config, str):
+            config = config_string_to_dict(config)
 
         if isinstance(config, FrozenDict):
             config = config._as_dict()

--- a/profane/cli.py
+++ b/profane/cli.py
@@ -1,3 +1,8 @@
+def config_string_to_dict(s):
+    s = " ".join(s.split())  # remove consecutive whitespace
+    return config_list_to_dict(s.split())
+
+
 def config_list_to_dict(l):
     d = {}
 

--- a/tests/test_task_pipeline.py
+++ b/tests/test_task_pipeline.py
@@ -327,6 +327,24 @@ def test_creation_with_config_string(rank_modules):
     assert rt2.config == rt3.config
 
 
+def test_creation_with_provide_obj(rank_modules):
+    ThreeRankTask, TwoRankTask, RankTask, RerankTask = rank_modules
+
+    benchmark = module_registry.lookup("benchmark", "trecdl")()
+    rt = RankTask("benchmark.name=rob04yang", provide=benchmark)
+
+    assert rt.benchmark == benchmark
+
+
+def test_creation_with_provide_list(rank_modules):
+    ThreeRankTask, TwoRankTask, RankTask, RerankTask = rank_modules
+
+    benchmark = module_registry.lookup("benchmark", "trecdl")()
+    rt = RankTask("benchmark.name=rob04yang", provide=[benchmark])
+
+    assert rt.benchmark == benchmark
+
+
 def test_registry_enumeration(rank_modules):
     assert module_registry.get_module_types() == [
         "benchmark",

--- a/tests/test_task_pipeline.py
+++ b/tests/test_task_pipeline.py
@@ -316,6 +316,17 @@ def test_prng_creation(rank_modules):
     assert not hasattr(rt.benchmark.collection, "rng")
 
 
+def test_creation_with_config_string(rank_modules):
+    ThreeRankTask, TwoRankTask, RankTask, RerankTask = rank_modules
+
+    rt1 = RankTask({"searcher": {"seed": 123, "index": {"stemmer": "other"}}})
+    rt2 = RankTask("searcher.seed=123 searcher.index.stemmer=other")
+    rt3 = RankTask("searcher.seed=456 searcher.seed=123 searcher.index.stemmer=other")
+
+    assert rt1.config == rt2.config
+    assert rt2.config == rt3.config
+
+
 def test_registry_enumeration(rank_modules):
     assert module_registry.get_module_types() == [
         "benchmark",


### PR DESCRIPTION
Make `ModuleBase.__init__` automatically convert several types of `config` and `provide` arguments:
- Allow `config` to be passed as a string, which is then converted to a config dict
- Allow `provide` to be passed as a list, which is converted to a dict in which keys correspond to module types. This is convenient for handling the common `collection` and `benchmark` cases where the type and dependency name are the same
- Allow `provide` to be passed as a single module object, which is converted to a list (and then to a dict as above)