### PR TITLE
Add argument to omit keys from module_path

### DIFF
--- a/example/collection/collections.py
+++ b/example/collection/collections.py
@@ -1,4 +1,4 @@
-from profane import ModuleBase, Dependency, ConfigOption
+from profane import ModuleBase
 
 
 class Collection(ModuleBase):

--- a/example/task/base.py
+++ b/example/task/base.py
@@ -1,4 +1,4 @@
-from profane import ModuleBase, Dependency, ConfigOption
+from profane import ModuleBase
 
 
 class Task(ModuleBase):

--- a/example/task/rank.py
+++ b/example/task/rank.py
@@ -1,4 +1,4 @@
-from profane import ModuleBase, Dependency, ConfigOption
+from profane import Dependency
 
 from task import Task
 

--- a/tests/test_task_pipeline.py
+++ b/tests/test_task_pipeline.py
@@ -345,6 +345,15 @@ def test_creation_with_provide_list(rank_modules):
     assert rt.benchmark == benchmark
 
 
+def test_skip_config_in_module_path(rank_modules):
+    ThreeRankTask, TwoRankTask, RankTask, RerankTask = rank_modules
+
+    rerank = RerankTask()
+    assert rerank.get_module_path().endswith("/task-rerank_fold-s1_optimize-map_seed-42")
+    assert rerank.get_module_path(skip_config_keys="fold").endswith("/task-rerank_optimize-map_seed-42")
+    assert rerank.get_module_path(skip_config_keys=["fold", "seed"]).endswith("/task-rerank_optimize-map")
+
+
 def test_registry_enumeration(rank_modules):
     assert module_registry.get_module_types() == [
         "benchmark",


### PR DESCRIPTION
`get_module_path` accepts a `skip_config_keys` argument containing config options that will not be included in the path