### PR TITLE
Range notation includes both endpoints

### DIFF
--- a/profane/config_option.py
+++ b/profane/config_option.py
@@ -88,11 +88,11 @@ def _parse_string_as_range(s, item_type):
         raise ValueError(f"invalid range: {s}")
 
     if item_type == int:
-        return list(range(start, stop, step))
+        return list(range(start, stop + step, step))
     elif item_type == float:
         precision = max(_rounding_precision(x) for x in (start, stop, step))
-        lst = [round(item, precision) for item in np.arange(start, stop, step)]
-        if lst[-1] == stop:
+        lst = [round(item, precision) for item in np.arange(start, stop + step, step)]
+        if lst[-1] > stop:
             del lst[-1]
         return lst
 
@@ -123,7 +123,7 @@ def convert_list_to_string(lst, item_type):
 
         if is_range:
             start = round(lst[0], precision)
-            stop = round(lst[-1] + step, precision)
+            stop = round(lst[-1], precision)
 
             start, stop, step = _unnecessary_floats_to_ints([start, stop, step])
             return f"{start}..{stop},{step}"

--- a/tests/test_config_types.py
+++ b/tests/test_config_types.py
@@ -73,10 +73,10 @@ def test_convert_string_to_list():
     assert convert_string_to_list("1", str) == ("1",)
 
     # test range conversions
-    assert convert_string_to_list("1..4,1", int) == (1, 2, 3)
-    assert convert_string_to_list("1..4,0.5", float) == (1, 1.5, 2, 2.5, 3, 3.5)
-    assert convert_string_to_list("0.65..0.8,0.05", float) == (0.65, 0.7, 0.75)
-    assert convert_string_to_list("0.00001..0.00002,2e-06", float) == (1e-05, 1.2e-05, 1.4e-05, 1.6e-05, 1.8e-05)
+    assert convert_string_to_list("1..4,1", int) == (1, 2, 3, 4)
+    assert convert_string_to_list("1..4,0.5", float) == (1, 1.5, 2, 2.5, 3, 3.5, 4.0)
+    assert convert_string_to_list("0.65..0.8,0.05", float) == (0.65, 0.7, 0.75, 0.80)
+    assert convert_string_to_list("0.00001..0.00002,2e-06", float) == (1e-05, 1.2e-05, 1.4e-05, 1.6e-05, 1.8e-05, 2.0e-05)
 
     # test range checking endpoints
     assert convert_string_to_list("1,2,3,4,6", int) == (1, 2, 3, 4, 6)
@@ -90,8 +90,8 @@ def test_convert_string_to_list():
 
 
 def test_convert_list_to_string():
-    assert convert_list_to_string([1.1, 1.3, 1.5, 1.7], float) == "1.1..1.9,0.2"
-    assert convert_list_to_string([1, 3, 5], int) == "1..7,2"
+    assert convert_list_to_string([1.1, 1.3, 1.5, 1.7], float) == "1.1..1.7,0.2"
+    assert convert_list_to_string([1, 3, 5], int) == "1..5,2"
 
     assert convert_list_to_string([1, 3, 4], int) == "1,3,4"
     assert convert_list_to_string([1, 3, 4.9999], float) == "1,3,4.9999"
@@ -108,8 +108,8 @@ def test_convert_list_to_string():
     assert convert_list_to_string(["1", "2"], str) == "1,2"
     assert convert_list_to_string(["1", "2", "3", "4"], str) == "1,2,3,4"
 
-    assert convert_list_to_string([1, 2, 3.0], float) == "1..4,1"
-    assert convert_list_to_string([1.5, 2, 2.5], float) == "1.5..3,0.5"
+    assert convert_list_to_string([1, 2, 3.0], float) == "1..3,1"
+    assert convert_list_to_string([1.5, 2, 2.5], float) == "1.5..2.5,0.5"
 
 
 @composite
@@ -130,7 +130,7 @@ def arithmetic_sequence(draw, dtype):
     else:
         raise ValueError(f"Unexpected dtype {dtype}")
 
-    lst = np.around(np.arange(start, end, step), decimals=4).tolist()
+    lst = np.around(np.arange(start, end + step, step), decimals=4).tolist()
     assert len(lst) > 0
     return lst
 


### PR DESCRIPTION
Change range string notation so that the right endpoint is included. That is,
`convert_string_to_list("1..4,1", int) == (1, 2, 3, 4)`.

This is a breaking change. Previously the right endpoint was not included.