### PR TITLE
Config files allow comments and expand ~

### DIFF
--- a/profane/base.py
+++ b/profane/base.py
@@ -82,13 +82,13 @@ module_registry = ModuleRegistry()
 
 
 class Dependency:
-    """ Represents a dependency on another module.
+    """Represents a dependency on another module.
 
-        If name is None, the dependency must be provided by the pipeline (i.e., in `provided_modules`).
-        Otherwise, the module class corresponding to `name` will be used.
+    If name is None, the dependency must be provided by the pipeline (i.e., in `provided_modules`).
+    Otherwise, the module class corresponding to `name` will be used.
 
-        If default_config_overrides is a dict, it will be used to override the dependency's default config options.
-        Note that user may still override these options e.g. on the command line.
+    If default_config_overrides is a dict, it will be used to override the dependency's default config options.
+    Note that user may still override these options e.g. on the command line.
     """
 
     def __init__(self, key, module, name=None, default_config_overrides=None, provide_this=False, provide_children=None):
@@ -117,18 +117,18 @@ class Dependency:
 
 
 class ModuleBase:
-    """ Base class for profane modules.
-        Module construction proceeds as follows:
-        1) Any config options not present in `config` are filled in with their default values. Config options and their defaults are specified in the `config_spec` class attribute.
-        2) Any dependencies declared in the `dependencies` class attribute are recursively instantiated. If the dependency object is present in `provide`, this object will be used instead of instantiating a new object for the dependency.
-        3) The module object's `config` variable is updated to reflect the configs of its dependencies and then frozen.
+    """Base class for profane modules.
+    Module construction proceeds as follows:
+    1) Any config options not present in `config` are filled in with their default values. Config options and their defaults are specified in the `config_spec` class attribute.
+    2) Any dependencies declared in the `dependencies` class attribute are recursively instantiated. If the dependency object is present in `provide`, this object will be used instead of instantiating a new object for the dependency.
+    3) The module object's `config` variable is updated to reflect the configs of its dependencies and then frozen.
 
-        After construction is complete, the module's dependencies are available as instance variables: self.`dependency key`.
+    After construction is complete, the module's dependencies are available as instance variables: self.`dependency key`.
 
-        Args:
-            config: dictionary containing a config to apply to this module and its dependencies
-            provide: dictionary mapping dependency keys to module objects 
-            share_dependency_objects: if true, dependencies will be cached in the registry based on their configs and reused. See the `share_objects` argument of `ModuleBase.create`.
+    Args:
+        config: dictionary containing a config to apply to this module and its dependencies
+        provide: dictionary mapping dependency keys to module objects
+        share_dependency_objects: if true, dependencies will be cached in the registry based on their configs and reused. See the `share_objects` argument of `ModuleBase.create`.
     """
 
     config_spec = []
@@ -143,8 +143,8 @@ class ModuleBase:
 
     @classmethod
     def _validate_and_cast_config(cls, config):
-        """ Validates `config` and casts values to their correct types.
-            Reraises an exception if any option present is not recognized or is incompatible with its type.
+        """Validates `config` and casts values to their correct types.
+        Reraises an exception if any option present is not recognized or is incompatible with its type.
         """
 
         options = {option.key: option for option in cls.config_spec}
@@ -209,13 +209,13 @@ class ModuleBase:
 
     @classmethod
     def create(cls, name, config=None, provide=None, share_objects=True):
-        """ Creates a module by looking up a `name` in the module registry corresponding to the calling class' module type.
-            `config` and `provide` are passed to the module's constructor.
+        """Creates a module by looking up a `name` in the module registry corresponding to the calling class' module type.
+        `config` and `provide` are passed to the module's constructor.
 
-            If `share_objects` is true:
-            - any instantiated module objects will be cached in the registry based on their configs
-            - when a module with the same config is created, the cached object is returned rather than a new instance
-            This behavior applies to any module dependencies as well.
+        If `share_objects` is true:
+        - any instantiated module objects will be cached in the registry based on their configs
+        - when a module with the same config is created, the cached object is returned rather than a new instance
+        This behavior applies to any module dependencies as well.
         """
 
         module_cls = module_registry.lookup(cls.module_type, name)
@@ -347,11 +347,11 @@ class ModuleBase:
             self.config[module_name] = module_obj.config
 
     def _set_random_seed(self, config):
-        """ If this module requires a random seed, set one and initialize the RNGs.
+        """If this module requires a random seed, set one and initialize the RNGs.
 
-            All modules must share the same seed, because they may make calls to the same RNGs (e.g., ``np.random``).
-            However, this can lead to non-deterministic behavior and should be avoided whenever possible.
-            Instead, modules should use their own numpy RNG at `self.rng` to avoid RNG interactions between modules. """
+        All modules must share the same seed, because they may make calls to the same RNGs (e.g., ``np.random``).
+        However, this can lead to non-deterministic behavior and should be avoided whenever possible.
+        Instead, modules should use their own numpy RNG at `self.rng` to avoid RNG interactions between modules."""
 
         if not self.requires_random_seed:
             return
@@ -366,8 +366,8 @@ class ModuleBase:
         config["seed"] = constants["RANDOM_SEED"]
 
     def get_cache_path(self, *args, **kwargs):
-        """ Return an absolute path that can be used for caching.
-            The path is a function of the module's config and the configs of its dependencies.
+        """Return an absolute path that can be used for caching.
+        The path is a function of the module's config and the configs of its dependencies.
         """
 
         return constants["CACHE_BASE_PATH"] / self.get_module_path(*args, **kwargs)

--- a/profane/cli.py
+++ b/profane/cli.py
@@ -1,3 +1,4 @@
+import os
 from shlex import shlex
 
 
@@ -56,7 +57,7 @@ def _config_list_to_pairs(l):
 
 def _config_file_to_list(fn):
     lst = []
-    with open(fn, "rt") as f:
+    with open(os.path.expanduser(fn), "rt") as f:
         for line in f:
             lex = shlex(line)
             lex.whitespace = ""

--- a/profane/cli.py
+++ b/profane/cli.py
@@ -1,3 +1,6 @@
+from shlex import shlex
+
+
 def config_string_to_dict(s):
     s = " ".join(s.split())  # remove consecutive whitespace
     return config_list_to_dict(s.split())
@@ -24,10 +27,8 @@ def _dot_to_dict(d, k, v):
         d.setdefault(current_k, {})
         _dot_to_dict(d[current_k], remaining_path, v)
     elif k.lower() == "file":
-        with open(v, "rt") as f:
-            pairs = [pair for line in f for pair in line.strip().split(" ")]
-
-        for new_k, new_v in _config_list_to_pairs(pairs):
+        lst = _config_file_to_list(v)
+        for new_k, new_v in _config_list_to_pairs(lst):
             _dot_to_dict(d, new_k, new_v)
     else:
         d[k] = v
@@ -51,3 +52,17 @@ def _config_list_to_pairs(l):
         pairs.append((k, v))
 
     return pairs
+
+
+def _config_file_to_list(fn):
+    lst = []
+    with open(fn, "rt") as f:
+        for line in f:
+            lex = shlex(line)
+            lex.whitespace = ""
+            kvs = "".join(list(lex))
+
+            for kv in kvs.strip().split():
+                lst.append(kv)
+
+    return lst

--- a/profane/config_option.py
+++ b/profane/config_option.py
@@ -6,8 +6,8 @@ from profane.exceptions import InvalidModuleError
 
 
 class ConfigOption:
-    """ Represents a config option required by a module.
-        When a module is created, any unspecified config options will receive `default_value`, 
+    """Represents a config option required by a module.
+        When a module is created, any unspecified config options will receive `default_value`,
         and all config options will be cast to value_type. The None type is considered to be a string.
         If one of the list types is used, the config option's value will always be provided to the module as a list.
         These lists can be converted to strings in list or range format when needed (see `ModuleBase._config_as_strings`).
@@ -100,10 +100,10 @@ def _parse_string_as_range(s, item_type):
 
 
 def convert_list_to_string(lst, item_type):
-    """ Convert a list to a string.
-        Try to represent it as a range if the list has more than two elements and item_type is float or int.
-        [1,2]       -> "1,2"
-        [1,2,3,4]   -> "1..5,1"
+    """Convert a list to a string.
+    Try to represent it as a range if the list has more than two elements and item_type is float or int.
+    [1,2]       -> "1,2"
+    [1,2,3,4]   -> "1..5,1"
     """
 
     lst = [item_type(x) for x in lst]

--- a/profane/constants.py
+++ b/profane/constants.py
@@ -1,6 +1,6 @@
 class ConstantsRegistry:
-    """ Write-once registry that keeps track of constants shared by modules.
-        ConstantsRegistry behaves like a dict, but keys can only be assigned to once.
+    """Write-once registry that keeps track of constants shared by modules.
+    ConstantsRegistry behaves like a dict, but keys can only be assigned to once.
     """
 
     def __init__(self):

--- a/tests/test_config_string.py
+++ b/tests/test_config_string.py
@@ -31,7 +31,8 @@ def test_config_string_to_dict():
 def test_config_string_with_files_to_dict(tmpdir):
     mainfn = os.path.join(tmpdir, "main.txt")
     with open(mainfn, "wt") as f:
-        print("main=24", file=f)
+        print("main=24  # comment", file=f)
+        print("#main=25", file=f)
 
     foofn = os.path.join(tmpdir, "foo.txt")
     with open(foofn, "wt") as f:


### PR DESCRIPTION
- Allow comments using the `#` character
- Expand `~` in the file path
- Black docstrings

Closes #14 and closes #15.