### PR TITLE
added support for YAML files

### DIFF
--- a/profane/cli.py
+++ b/profane/cli.py
@@ -1,5 +1,6 @@
 import os
 from shlex import shlex
+import yaml
 
 
 def config_string_to_dict(s):
@@ -16,6 +17,30 @@ def config_list_to_dict(l):
     return d
 
 
+def _recursive_update(ori_dict, new_dict):
+    for k in new_dict:
+        if k not in ori_dict:
+            ori_dict[k] = new_dict[k]
+        elif not isinstance(ori_dict[k], dict):
+            ori_dict[k] = new_dict[k]
+        else:
+            ori_value, new_value = ori_dict[k], new_dict[k]
+            ori_dict[k] = _recursive_update(ori_value, new_value)
+    return ori_dict
+
+
+def _load_yaml(fn):
+    with open(fn) as f:
+        config = yaml.load(f)
+
+    if "_base_" in config:
+        base_path = config["_base_"]
+        base_config = _load_yaml(base_path)
+        config = _recursive_update(ori_dict=base_config, new_dict=config)
+        del config["_base_"]
+
+    return config
+
 def _dot_to_dict(d, k, v):
     if k.startswith(".") or k.endswith("."):
         raise ValueError(f"invalid path: {k}")
@@ -28,9 +53,14 @@ def _dot_to_dict(d, k, v):
         d.setdefault(current_k, {})
         _dot_to_dict(d[current_k], remaining_path, v)
     elif k.lower() == "file":
-        lst = _config_file_to_list(v)
-        for new_k, new_v in _config_list_to_pairs(lst):
-            _dot_to_dict(d, new_k, new_v)
+        ext = os.path.splitext(v)[1]
+        if ext == '.yaml':
+            y = _load_yaml(v)
+            d.update(y)
+        else:        
+            lst = _config_file_to_list(v)
+            for new_k, new_v in _config_list_to_pairs(lst):
+                _dot_to_dict(d, new_k, new_v)
     else:
         d[k] = v
 
@@ -57,13 +87,17 @@ def _config_list_to_pairs(l):
 
 def _config_file_to_list(fn):
     lst = []
-    with open(os.path.expanduser(fn), "rt") as f:
-        for line in f:
-            lex = shlex(line)
-            lex.whitespace = ""
-            kvs = "".join(list(lex))
-
-            for kv in kvs.strip().split():
-                lst.append(kv)
+    ext = os.path.splitext(fn)[1]
+    if ext == 'yaml':
+        yaml_list = _load_yaml(fn)
+        lst.extend(yaml_list)
+    else:
+        with open(os.path.expanduser(fn), "rt") as f:
+            for line in f:
+                lex = shlex(line)
+                lex.whitespace = ""
+                kvs = "".join(list(lex))
+                for kv in kvs.strip().split():
+                    lst.append(kv)
 
     return lst

--- a/profane/cli.py
+++ b/profane/cli.py
@@ -18,21 +18,6 @@ def config_list_to_dict(l):
     return d
 
 
-
-
-def _deep_update(source, overrides):
-    """
-    Update a nested dictionary or similar mapping.
-    Modify ``source`` in place.
-    """
-    for key, value in overrides.items():
-        if isinstance(value, collections.abc.Mapping) and value:
-            returned = _deep_update(source.get(key, {}), value)
-            source[key] = returned
-        else:
-            source[key] = overrides[key]
-    return source
-
 def _recursive_update(ori_dict, new_dict):
     for k in new_dict:
         if k not in ori_dict:

--- a/profane/cli.py
+++ b/profane/cli.py
@@ -48,13 +48,6 @@ def _recursive_update(ori_dict, new_dict):
 def _load_yaml(fn):
     with open(fn) as f:
         config = yaml.safe_load(f)
-
-    if "_base_" in config:
-        base_path = config["_base_"]
-        base_config = _load_yaml(base_path)
-        config = _recursive_update(ori_dict=base_config, new_dict=config)
-        del config["_base_"]
-
     return config
 
 def _flatten(d, parent_key='', sep='.'):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ docopt
 hypothesis
 numpy>=1.17
 pytest
+PyYAML==5.3.1
 sqlalchemy~=1.3.19 # needed until new sqlalchemy-utils release
 sqlalchemy-utils~=0.36.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ docopt
 hypothesis
 numpy>=1.17
 pytest
-PyYAML==5.3.1
+PyYAML>=5
 sqlalchemy~=1.3.19 # needed until new sqlalchemy-utils release
 sqlalchemy-utils~=0.36.8

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/andrewyates/profane",
     packages=setuptools.find_packages(),
-    install_requires=["colorama", "docopt", "numpy>=1.17", "sqlalchemy", "sqlalchemy-utils"],
+    install_requires=["colorama", "docopt", "numpy>=1.17", "PyYAML>=5", "sqlalchemy", "sqlalchemy-utils"],
     classifiers=["Programming Language :: Python :: 3", "Operating System :: OS Independent"],
     python_requires=">=3.6",
     cmdclass={"develop": PostDevelopCommand, "install": PostInstallCommand},

--- a/tests/test_config_string.py
+++ b/tests/test_config_string.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+import yaml
 
 from profane.cli import config_list_to_dict
 
@@ -46,3 +47,30 @@ def test_config_string_with_files_to_dict(tmpdir):
         "foo": {"test1": "20", "test3": "extra", "main": "24", "submod1": {"test1": "21", "submod2": {"test1": "22"}}},
         "main": "24",
     }
+
+def test_config_string_with_yaml_files_to_dict(tmpdir):
+    mainfn = os.path.join(tmpdir, "main.yaml")
+
+    main_data = dict(
+        main = 24,
+    )
+    with open(mainfn, "wt") as f:
+        yaml.dump(main_data, f, default_flow_style=False)
+    
+    foo_data = dict(
+        test1=20,
+        submod1=dict(test1=21, submod2=dict(test1=22)),
+        test3="extra",
+        FILE=mainfn
+    )  
+
+    foofn = os.path.join(tmpdir, "foo.yaml")
+    with open(foofn, "wt") as f:
+        yaml.dump(foo_data, f, default_flow_style=False)
+
+    args = ["foo.test1=1", f"foo.file={foofn}", "main=42", f"file={mainfn}"]
+    assert config_list_to_dict(args) == {
+        "foo": {"test1": "20", "test3": "extra", "main": "24", "submod1": {"test1": "21", "submod2": {"test1": "22"}}},
+        "main": "24",
+    }
+    


### PR DESCRIPTION
I added support for YAML. Previously only files with this format (`A.B.C.D=E`) were supported. However, the downside is redundant characters which may cause confusion. For example:
```
A.B.C.D=1
A.B.C.E=2
A.B.C.F=3
A.B.C.G=4
A.B.C.H=5
```
Can now be simply represented as follows:
```
'A':
  'B':
    'C':
      'D': 1
      'E': 2
      'F': 3
      'G': 4
      'H': 5
```

In addition, there is a special field `_base_` which allows for a more modular design. Say we have two configs, conf1 and conf2 which share most of the variables but only differ in one.
In the old format, we have to do 
conf1.txt
```
A.B.C=1
A.B.D=2
A.B.E=3
A.B.F=4
A.B.G=5
A.B.H=10
```
conf2.txt
```
A.B.C=1
A.B.D=2
A.B.E=3
A.B.F=4
A.B.G=5
A.B.H=20
```

Note that here only the `A.B.H` field is different, yet we are repeat several field unnecessarily. This can be written in our `yaml` format as follows:
confbase.yaml
```
'A':
  'B':
    'C': 1
    'D': 2
    'E': 3
    'F': 4
    'G': 5
```

conf1.yaml
```
_base_: 'confbase.yaml'
'A':
  'B':
    'C':
      'H': 10
```

conf2.yaml
```
_base_: 'confbase.yaml'
'A':
  'B':
    'C':
      'H': 20
```

This encourages modularity and reusability.

For a simple test, you can consider using: 
base.yaml
```
'benchmark':
  'collection':
    'name':
      'robust04'
'searcher':
  'name':
    'BM25'
  'seed':
    12345
```
conf.yaml
```
'_base_':
  'base.yaml'
'benchmark':
  'name': 'wsdm20demo'
```

`python run.py rank.run with file=test.yaml`
