### PR TITLE
Enable check for invalid seed configuration

### DIFF
--- a/profane/base.py
+++ b/profane/base.py
@@ -157,9 +157,8 @@ class ModuleBase:
             elif key == "seed":
                 if not cls.requires_random_seed:
                     raise InvalidConfigError(f"seed={config[key]} was provided but cls.requires_random_seed=False")
-                # this cannot happen because we overwrite the seed in module init
-                # if config["seed"] != constants.RANDOM_SEED:
-                #    raise InvalidConfigError(f"seed={config[key]} does not match constants.RANDOM_SEED={constants.RANDOM_SEED}")
+                if config["seed"] != constants.RANDOM_SEED:
+                    raise InvalidConfigError(f"seed={config[key]} does not match constants.RANDOM_SEED={constants.RANDOM_SEED}. This indicates that different seeds were configured within the same process which is not possible. Please start a new process for each different seed.")
             elif key in dependencies:
                 if isinstance(config[key], str):
                     raise InvalidConfigError(


### PR DESCRIPTION
Dear all,

Thank you for providing this nice library. I use it in combination with capreolus and really appreciate it.

I saw that the seed configuration is ignored when a seed was already configured before. This is not a problem when I train a single re-ranker in capreolus from the cli. Still, when I train multiple re-rankers with different seeds from a Jupyter notebook, all use the same seed (because it is the same process, the [constants already contain the seed of the first configuration which is then reused](https://github.com/andrewyates/profane/blob/master/profane/base.py#L360)).

I think it would be a good solution to [raise the InvalidConfigError](https://github.com/andrewyates/profane/blob/master/profane/base.py#L162) or is there a reason why the line is commented out? I included some more details in the error message.

Best Regards,

Maik